### PR TITLE
Added redirect page and logic post-sign in

### DIFF
--- a/pages/signin.js
+++ b/pages/signin.js
@@ -2,7 +2,6 @@ import { providers, signIn, getSession } from "next-auth/client";
 import Box from "@material-ui/core/Box";
 import { makeStyles } from "@material-ui/core/styles";
 import LoginBox from "common/widgets/LoginBox";
-import { useRouter } from "next/router";
 
 const useStyles = makeStyles((theme) => ({
   videoContainer: {
@@ -47,15 +46,15 @@ export async function getServerSideProps(context) {
   // Redirect user if visiting signIn page while signed in
   if (session) {
     res.writeHead(302, {
-      Location: process.env.NEXTAUTH_URL,
+      Location: "/welcome",
     });
     res.end();
-    return {};
+    return { props: {} };
   }
   return {
     props: {
       session: null,
-      providers: await providers(context),
+      providers: (await providers(context)) || {},
     },
   };
 }

--- a/pages/welcome.js
+++ b/pages/welcome.js
@@ -1,0 +1,39 @@
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import { useSession } from "next-auth/client";
+import { makeStyles } from "@material-ui/core/styles";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: "100vw",
+    height: "100vh",
+    overflow: "hidden",
+  },
+}));
+
+export default function Welcome() {
+  const [session, loading] = useSession();
+  const classes = useStyles();
+  const router = useRouter();
+
+  useEffect(() => {
+    session && setTimeout(() => router.push("/"), 2000);
+  }, [session]);
+
+  return (
+    <Grid
+      container
+      justify="center"
+      alignItems="center"
+      className={classes.root}
+    >
+      {session && (
+        <Typography variant="h2" color="primary">
+          {`Welcome back, ${session.user.name}`}
+        </Typography>
+      )}
+    </Grid>
+  );
+}


### PR DESCRIPTION
In production we're having some difficultly with the sign in redirecting to the correct page after a sign in. This should correct it, using an intermediary page as the redirect for writeHead.